### PR TITLE
Deprecate riscv gcc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "hw/tools/riscv-opcodes"]
 	path = hw/tools/riscv-opcodes
 	url = https://github.com/ucb-bar/riscv-opcodes.git
-[submodule "hw/tools/riscv-gcc"]
-	path = hw/tools/riscv-gcc
-	url = https://github.com/ucb-bar/riscv-gcc

--- a/README.md
+++ b/README.md
@@ -16,18 +16,23 @@ As of november 2014 we are still building the hw infrastructure
 necessary to run a software stack on top of. So here we present only
 how to get started with hw-development.
 
-1. Install dependencies
+# Install packaged dependencies
 
    yaourt -S sbt texlive-most
 
-2. Enter the core directory
+# Install (yet) un-packaged dependencies
+
+  Install the GNU toolchain for RISC-V from
+  https://github.com/ucb-bar/riscv-gnu-toolchain
+
+# Enter the core directory
 
    cd hw/core
 
-3. Test your environment
+# Test your environment
 
    make alu.test
 
-4. Peruse the issue-tracker to see if there is anything that interests
+# Peruse the issue-tracker to see if there is anything that interests
 you or create your own issue based on what you want to contribute
 with. But most importantly; have fun!


### PR DESCRIPTION
There are two changes in this pull-request.

Change the way we satisfy our compiler-dependency from being git
submodule based to being "Go there and compile it from source you
twat" based. And change what compiler we use.

Optimally our compiler-dependency would be satisified by a
package, but no-one has created one yet and I found it
disappointingly tricky to create one myself. I believe that it is
unnecessary to have a git submodule when we are not going to
contribute back to the compiler. But this can be debated, thus
the pull-request.

We change the compiler used from riscv-gcc to riscv-gnu-toolchain
because riscv-gcc is deprecated[1].

[1] https://github.com/ucb-bar/riscv-gcc/issues/17#issuecomment-65880456
